### PR TITLE
[Feat] 장소에 작성된 리뷰 리스트 조회 로직 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/communityPlace/controller/CommunityPlaceController.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/controller/CommunityPlaceController.java
@@ -3,12 +3,16 @@ package com.samsamhajo.deepground.communityPlace.controller;
 
 import com.samsamhajo.deepground.auth.security.CustomUserDetails;
 import com.samsamhajo.deepground.communityPlace.dto.request.CreateReviewDto;
+import com.samsamhajo.deepground.communityPlace.dto.response.ReviewListResponseDto;
 import com.samsamhajo.deepground.communityPlace.dto.response.ReviewResponseDto;
 import com.samsamhajo.deepground.communityPlace.exception.CommunityPlaceSuccessCode;
 import com.samsamhajo.deepground.communityPlace.service.CommunityPlaceService;
 import com.samsamhajo.deepground.global.success.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -55,6 +59,17 @@ public class CommunityPlaceController {
         return ResponseEntity
                 .ok(SuccessResponse.of(CommunityPlaceSuccessCode.COMMUNITYPLACE_SUCCESS_SELECT,reviewData));
 
+    }
+
+    @GetMapping("/{placeId}")
+    public ResponseEntity<SuccessResponse> getCommunityPlaceReviews(
+            @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @PathVariable Long placeId) {
+        ReviewListResponseDto reviewListResponseDto = communityPlaceService.SearchReviews(placeId, pageable);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.of(CommunityPlaceSuccessCode.COMMUNITY_PLACE_SUCCESS_SEARCH, reviewListResponseDto));
     }
 }
 

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/dto/request/CreateReviewDto.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/dto/request/CreateReviewDto.java
@@ -22,6 +22,7 @@ public class CreateReviewDto {
     @NotNull(message = "주소 정보는 필수입니다.")
     @Valid
     private AddressDto address;
+    private Long placeId;
     private List<MultipartFile> images = new ArrayList<>();
 
 

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/dto/request/SearchReviewSummaryDto.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/dto/request/SearchReviewSummaryDto.java
@@ -1,0 +1,28 @@
+package com.samsamhajo.deepground.communityPlace.dto.request;
+
+import com.samsamhajo.deepground.communityPlace.entity.CommunityPlaceReview;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SearchReviewSummaryDto {
+
+    private Long reviewId;
+    private Long placeId;
+    private double scope;
+    private String content;
+    private List<String> mediaUrl;
+
+    public SearchReviewSummaryDto(Long reviewId, Long placeId, double scope, String content, List<String> mediaUrl) {
+        this.reviewId = reviewId;
+        this.placeId = placeId;
+        this.scope = scope;
+        this.content = content;
+        this.mediaUrl = mediaUrl;
+    }
+    public static SearchReviewSummaryDto of(CommunityPlaceReview c, List<String> mediaUrl) {
+        return new SearchReviewSummaryDto(c.getId(), c.getPlaceId(), c.getScope(), c.getContent(), mediaUrl);
+    }
+
+}

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/dto/response/ReviewListResponseDto.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/dto/response/ReviewListResponseDto.java
@@ -1,0 +1,22 @@
+    package com.samsamhajo.deepground.communityPlace.dto.response;
+
+    import com.samsamhajo.deepground.communityPlace.dto.request.SearchReviewSummaryDto;
+    import lombok.Getter;
+
+    import java.util.List;
+
+    @Getter
+    public class ReviewListResponseDto {
+        private List<SearchReviewSummaryDto> reviews;
+        private int totalPages;
+
+        public static ReviewListResponseDto of(List<SearchReviewSummaryDto> reviews, int totalPages) {
+            return new ReviewListResponseDto(reviews, totalPages);
+        }
+
+        private ReviewListResponseDto(List<SearchReviewSummaryDto> reviews, int totalPages) {
+            this.reviews = reviews;
+            this.totalPages = totalPages;
+        }
+
+    }

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/dto/response/ReviewResponseDto.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/dto/response/ReviewResponseDto.java
@@ -12,10 +12,11 @@ public class ReviewResponseDto {
     private double latitude;
     private double longitude;
     private Long memberId;
+    private Long placeId;
     private List<String> mediaUrls;
 
     public ReviewResponseDto(Long id, double scope, String content,
-                             String location, double latitude, double longitude, Long memberId,
+                             String location, double latitude, double longitude, Long memberId, Long placeId,
                              List<String> mediaUrls) {
         this.id = id;
         this.scope = scope;
@@ -24,12 +25,13 @@ public class ReviewResponseDto {
         this.latitude = latitude;
         this.longitude = longitude;
         this.memberId = memberId;
+        this.placeId = placeId;
         this.mediaUrls = mediaUrls;
     }
 
     public static ReviewResponseDto of(Long id, double scope, String content,
-                                       String location, double latitude, double longitude, Long memberId,
+                                       String location, double latitude, double longitude, Long memberId, Long placeId,
                                        List<String> mediaUrls) {
-        return new ReviewResponseDto(id, scope, content, location, latitude, longitude, memberId, mediaUrls);
+        return new ReviewResponseDto(id, scope, content, location, latitude, longitude, memberId,placeId, mediaUrls);
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/entity/CommunityPlaceReview.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/entity/CommunityPlaceReview.java
@@ -25,6 +25,9 @@ public class CommunityPlaceReview extends BaseEntity {
     @Column(name = "community_place_content")
     private String content;
 
+    @Column(name = "place_id")
+    private Long placeId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -34,14 +37,15 @@ public class CommunityPlaceReview extends BaseEntity {
     @JsonBackReference //순환참조 방지 : (Depth 깊이 에러 발생)
     private SpecificAddress specificAddress;
 
-    private CommunityPlaceReview(double scope,String content, Member member){
+    private CommunityPlaceReview(double scope,String content, Long placeId, Member member){
         this.scope = scope;
         this.content = content;
+        this.placeId = placeId;
         this.member = member;
     }
 
-    public static CommunityPlaceReview of(double scope,String content, Member member, SpecificAddress specificAddress) {
-        CommunityPlaceReview review = new CommunityPlaceReview(scope, content, member);
+    public static CommunityPlaceReview of(double scope,String content, Long placeId, Member member, SpecificAddress specificAddress) {
+        CommunityPlaceReview review = new CommunityPlaceReview(scope, content, placeId, member);
         review.specificAddress = specificAddress;
         specificAddress.getCommunityPlaceReviews().add(review);
         return review;

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/exception/CommunityPlaceSuccessCode.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/exception/CommunityPlaceSuccessCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum CommunityPlaceSuccessCode implements SuccessCode {
 
     REVIEW_CREATED(HttpStatus.CREATED, "리뷰가 정상적으로 생성되었습니다."),
-    COMMUNITYPLACE_SUCCESS_SELECT(HttpStatus.OK, "스터디 장소가 성공적으로 조회됐습니다");
+    COMMUNITYPLACE_SUCCESS_SELECT(HttpStatus.OK, "스터디 장소가 성공적으로 조회됐습니다"),
+    COMMUNITY_PLACE_SUCCESS_SEARCH(HttpStatus.OK, "해당 장소의 리뷰가 성공적으로 조회됐습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/repository/CommunityPlaceRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/repository/CommunityPlaceRepository.java
@@ -1,9 +1,13 @@
 package com.samsamhajo.deepground.communityPlace.repository;
 
 import com.samsamhajo.deepground.communityPlace.entity.CommunityPlaceReview;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommunityPlaceRepository extends JpaRepository<CommunityPlaceReview,Long> {
+    Page<CommunityPlaceReview> findByPlaceId(Long placeId, Pageable pageable);
+
 }

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/service/CommunityPlaceService.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/service/CommunityPlaceService.java
@@ -68,6 +68,7 @@ public class CommunityPlaceService {
         CommunityPlaceReview review = CommunityPlaceReview.of(
                 createReviewDto.getScope(),
                 createReviewDto.getContent(),
+                createReviewDto.getPlaceId(),
                 member,
                 address
 
@@ -88,6 +89,7 @@ public class CommunityPlaceService {
                 point.getY(), // latitude(위도)
                 point.getX(),// longitude(경도)
                 member.getId(),
+                review.getPlaceId(),
                 mediaUrl
         );
 

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/service/CommunityPlaceService.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/service/CommunityPlaceService.java
@@ -135,6 +135,6 @@ public class CommunityPlaceService {
         return ReviewListResponseDto.of(reviews, reviewPage.getTotalPages());
     }
 
-    //TODO : 후에 스터디 일정 생성 시 가게정보 저장 로직 완료되면 테스트 예정
+    //TODO : 후에 스터디 일정 생성 시 가게정보 저장 로직 완료되면 테스트 예정 + N개의 리뷰마다 N번의 미디어 조회가 발생하기 때문에, 추후에 리팩토링 예정
 }
 


### PR DESCRIPTION
## 📌 개요

모임장소 카카오 맵에서 해당 장소를 클릭 후, 리뷰를 클릭하면 해당 장소에 대한 리뷰 리스트 목록 조회

## 🛠️ 작업 내용
- [ ] Pageable을 사용하여, 리뷰를 페이지당 5개씩 표시되도록 로직 구현
- [ ] 리뷰별로, media를 조회
- [ ] 별점, 리뷰내용, 이미지, placeId 조회

## 📌 차후 계획 (Optional)

해당 리뷰 상세 조회 & 테스트 코드 작성


## 📌 테스트 케이스
- [ ] 기능 정상 동작 확인
- [ ] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [ ] 코드 스타일 및 컨벤션 준수 확인
- [ ] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 특정 장소(placeId)에 대한 리뷰 목록을 페이지네이션 방식으로 조회할 수 있는 엔드포인트가 추가되었습니다.
  * 리뷰 생성 및 응답 시 placeId 정보가 포함됩니다.
  * 리뷰 요약에 미디어 URL이 포함되어 더욱 풍부한 정보 제공이 가능합니다.

* **기타**
  * 리뷰 요약 및 목록 응답 구조가 개선되어, 미디어 URL 등 추가 정보가 함께 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->