### PR TITLE
[Fix] CommunityPlace 통계 조회 시 DTO 변환 오류 수정 및 구조 리팩토링

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/communityPlace/controller/CommunityPlaceController.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/controller/CommunityPlaceController.java
@@ -2,6 +2,7 @@ package com.samsamhajo.deepground.communityPlace.controller;
 
 
 import com.samsamhajo.deepground.auth.security.CustomUserDetails;
+import com.samsamhajo.deepground.communityPlace.dto.CommunityPlaceReviewDto;
 import com.samsamhajo.deepground.communityPlace.dto.ReviewStatistics;
 import com.samsamhajo.deepground.communityPlace.dto.request.CreateReviewDto;
 import com.samsamhajo.deepground.communityPlace.dto.request.ReviewDetailDto;
@@ -67,18 +68,18 @@ public class CommunityPlaceController {
     }
   
     @GetMapping("/ByReviewCount")
-    public ResponseEntity<SuccessResponse<List<ReviewStatistics>>> selectCommunityPlaceByReviewCount() {
+    public ResponseEntity<SuccessResponse<List<CommunityPlaceReviewDto>>> selectCommunityPlaceByReviewCount() {
 
-        List<ReviewStatistics> communityPlaceReview = communityPlaceService.selectCommunityPlaceByReviewCount();
+        List<CommunityPlaceReviewDto> communityPlaceReview = communityPlaceService.selectCommunityPlaceByReviewCount();
 
         return ResponseEntity
                 .ok(SuccessResponse.of(CommunityPlaceSuccessCode.COMMUNITYPLACE_SUCCESS_SELECT_BY_REVIEW_COUNT,communityPlaceReview));
     }
 
     @GetMapping("/ByReviewScope")
-    public ResponseEntity<SuccessResponse<List<ReviewStatistics>>> selectCommunityPlaceByReviewScope() {
+    public ResponseEntity<SuccessResponse<List<CommunityPlaceReviewDto>>> selectCommunityPlaceByReviewScope() {
 
-        List<ReviewStatistics> communityPlaceReview = communityPlaceService.selectCommunityPlaceByReviewScope();
+        List<CommunityPlaceReviewDto> communityPlaceReview = communityPlaceService.selectCommunityPlaceByReviewScope();
 
         return ResponseEntity
                 .ok(SuccessResponse.of(CommunityPlaceSuccessCode.COMMUNITYPLACE_SUCCESS_SELECT_BY_REVIEW_SCOPE,communityPlaceReview));

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/controller/CommunityPlaceController.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/controller/CommunityPlaceController.java
@@ -2,7 +2,7 @@ package com.samsamhajo.deepground.communityPlace.controller;
 
 
 import com.samsamhajo.deepground.auth.security.CustomUserDetails;
-import com.samsamhajo.deepground.communityPlace.dto.CommunityPlaceReviewDto;
+import com.samsamhajo.deepground.communityPlace.dto.ReviewStatistics;
 import com.samsamhajo.deepground.communityPlace.dto.request.CreateReviewDto;
 import com.samsamhajo.deepground.communityPlace.dto.request.ReviewDetailDto;
 import com.samsamhajo.deepground.communityPlace.dto.response.ReviewListResponseDto;
@@ -20,7 +20,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import com.samsamhajo.deepground.communityPlace.entity.CommunityPlaceReview;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/communityplace")
+@RequestMapping("/communityPlace")
 @RequiredArgsConstructor
 public class CommunityPlaceController {
 
@@ -50,7 +49,7 @@ public class CommunityPlaceController {
     @GetMapping("/{specificAddressId}")
     public ResponseEntity<SuccessResponse> selectCommunityPlaceReviewsAndScope(@PathVariable Long specificAddressId) {
 
-        CommunityPlaceReview reviewData = communityPlaceService.selectCommunityPlaceReviewsAndScope(specificAddressId);
+        ReviewStatistics reviewData = communityPlaceService.selectCommunityPlaceReviewsAndScope(specificAddressId);
         return ResponseEntity
                 .ok(SuccessResponse.of(CommunityPlaceSuccessCode.COMMUNITYPLACE_SUCCESS_SELECT,reviewData));
 
@@ -68,18 +67,18 @@ public class CommunityPlaceController {
     }
   
     @GetMapping("/ByReviewCount")
-    public ResponseEntity<SuccessResponse<List<CommunityPlaceReviewDto>>> selectCommunityPlaceByReviewCount() {
+    public ResponseEntity<SuccessResponse<List<ReviewStatistics>>> selectCommunityPlaceByReviewCount() {
 
-        List<CommunityPlaceReviewDto> communityPlaceReview = communityPlaceService.selectCommunityPlaceByReviewCount();
+        List<ReviewStatistics> communityPlaceReview = communityPlaceService.selectCommunityPlaceByReviewCount();
 
         return ResponseEntity
                 .ok(SuccessResponse.of(CommunityPlaceSuccessCode.COMMUNITYPLACE_SUCCESS_SELECT_BY_REVIEW_COUNT,communityPlaceReview));
     }
 
     @GetMapping("/ByReviewScope")
-    public ResponseEntity<SuccessResponse<List<CommunityPlaceReviewDto>>> selectCommunityPlaceByReviewScope() {
+    public ResponseEntity<SuccessResponse<List<ReviewStatistics>>> selectCommunityPlaceByReviewScope() {
 
-        List<CommunityPlaceReviewDto> communityPlaceReview = communityPlaceService.selectCommunityPlaceByReviewScope();
+        List<ReviewStatistics> communityPlaceReview = communityPlaceService.selectCommunityPlaceByReviewScope();
 
         return ResponseEntity
                 .ok(SuccessResponse.of(CommunityPlaceSuccessCode.COMMUNITYPLACE_SUCCESS_SELECT_BY_REVIEW_SCOPE,communityPlaceReview));

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/dto/ReviewStatistics.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/dto/ReviewStatistics.java
@@ -7,14 +7,14 @@ import lombok.Getter;
 public class ReviewStatistics {
 
     private double avgScope;
-    private Long countContent;
+    private Long reviewCount;
 
-    public ReviewStatistics (double avgScope,Long countContent) {
+    public ReviewStatistics (double avgScope,Long reviewCount) {
         this.avgScope = avgScope;
-        this.countContent = countContent;
+        this.reviewCount = reviewCount;
     }
 
-    public static ReviewStatistics of(double avgScope,Long countContent) {
-        return new ReviewStatistics(avgScope,countContent);
+    public static ReviewStatistics of(double avgScope,Long reviewCount) {
+        return new ReviewStatistics(avgScope,reviewCount);
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/dto/ReviewStatistics.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/dto/ReviewStatistics.java
@@ -1,28 +1,20 @@
 package com.samsamhajo.deepground.communityPlace.dto;
 
-import com.samsamhajo.deepground.communityPlace.dto.response.ReviewResponseDto;
-import com.samsamhajo.deepground.communityPlace.entity.CommunityPlaceReview;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.awt.*;
-
 @Getter
-@Builder
-public class CommunityPlaceReviewDto {
+public class ReviewStatistics {
 
-    private Long id;
-    private String name;
     private double avgScope;
     private Long countContent;
-    private Long phone;
 
-    public static CommunityPlaceReviewDto from(CommunityPlaceReview review) {
-        return CommunityPlaceReviewDto.builder()
-                .id(review.getId())
-                .avgScope(review.getScope())
-                .countContent(review.getContent())
-                .build();
+    public ReviewStatistics (double avgScope,Long countContent) {
+        this.avgScope = avgScope;
+        this.countContent = countContent;
     }
 
+    public static ReviewStatistics of(double avgScope,Long countContent) {
+        return new ReviewStatistics(avgScope,countContent);
+    }
 }

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/dto/ReviewStatistics.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/dto/ReviewStatistics.java
@@ -1,0 +1,28 @@
+package com.samsamhajo.deepground.communityPlace.dto;
+
+import com.samsamhajo.deepground.communityPlace.dto.response.ReviewResponseDto;
+import com.samsamhajo.deepground.communityPlace.entity.CommunityPlaceReview;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.awt.*;
+
+@Getter
+@Builder
+public class CommunityPlaceReviewDto {
+
+    private Long id;
+    private String name;
+    private double avgScope;
+    private Long countContent;
+    private Long phone;
+
+    public static CommunityPlaceReviewDto from(CommunityPlaceReview review) {
+        return CommunityPlaceReviewDto.builder()
+                .id(review.getId())
+                .avgScope(review.getScope())
+                .countContent(review.getContent())
+                .build();
+    }
+
+}

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/exception/CommunityPlaceErrorCode.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/exception/CommunityPlaceErrorCode.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommunityPlaceErrorCode implements ErrorCode {
     COMMUNITYPLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 스터디장소는 찾을 수 없습니다"),
-    REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 리뷰가 없습니다.");
+    REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 리뷰가 없습니다."),
+    REVIEW_COUNT_NOT_FOUND(HttpStatus.NOT_FOUND,"댓글을 찾을 수 없습니다"),
+    REVIEW_AVG_SCOPE_NOT_FOUND(HttpStatus.NOT_FOUND,"평점을 찾을 수 없습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/repository/SpecificAddressRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/repository/SpecificAddressRepository.java
@@ -15,11 +15,6 @@ import java.util.Optional;
 @Repository
 public interface SpecificAddressRepository extends JpaRepository<SpecificAddress,Long> {
 
-    @Query("SELECT AVG(cpr.scope), COUNT(cpr.content) FROM SpecificAddress sa " +
-            "JOIN sa.communityPlaceReviews cpr " +
-            "WHERE sa.id = :specificAddressId")
-    Optional<CommunityPlaceReview> findByIdCountReviewsAndScopeAverage(@Param("specificAddressId") Long specificAddressId);
-
     Optional<SpecificAddress> findByNameAndLocation(String name, String location);
 
     @Query("SELECT sa.name, sa.number " +
@@ -35,4 +30,10 @@ public interface SpecificAddressRepository extends JpaRepository<SpecificAddress
             "GROUP BY sa.name, sa.number " +
             "ORDER BY AVG(r.scope) DESC")
     List<CommunityPlaceReviewDto> findAllCommunityPlaceByReviewScopeDesc();
+
+    @Query("SELECT AVG(r.scope) FROM SpecificAddress sa Left Join sa.communityPlaceReviews r WHERE sa.id = :specificAddressId")
+    Double avgScopeBySpecificAddressId( @Param("specificAddressId") Long specificAddressId);
+
+    @Query("SELECT COUNT(r) FROM SpecificAddress sa Left Join sa.communityPlaceReviews r WHERE sa.id = :specificAddressId")
+    Long countReviewBySpecificAddressId( @Param("specificAddressId") Long specificAddressId);
 }

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/service/CommunityPlaceService.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/service/CommunityPlaceService.java
@@ -114,7 +114,13 @@ public class CommunityPlaceService {
                 .orElseThrow(() -> new CommunityPlaceException(CommunityPlaceErrorCode.COMMUNITYPLACE_NOT_FOUND));
 
         Double avgScope = specificAddressRepository.avgScopeBySpecificAddressId(specificAddressId);
+        if (avgScope == null) {
+            throw new CommunityPlaceException(CommunityPlaceErrorCode.REVIEW_COUNT_NOT_FOUND);
+        }
         Long reviewCount = specificAddressRepository.countReviewBySpecificAddressId(specificAddressId);
+        if (reviewCount == null) {
+            throw new CommunityPlaceException(CommunityPlaceErrorCode.REVIEW_AVG_SCOPE_NOT_FOUND);
+        }
 
         return ReviewStatistics.of(avgScope,reviewCount);
     }

--- a/src/main/java/com/samsamhajo/deepground/communityPlace/service/CommunityPlaceService.java
+++ b/src/main/java/com/samsamhajo/deepground/communityPlace/service/CommunityPlaceService.java
@@ -2,6 +2,7 @@ package com.samsamhajo.deepground.communityPlace.service;
 
 
 import com.samsamhajo.deepground.communityPlace.dto.CommunityPlaceReviewDto;
+import com.samsamhajo.deepground.communityPlace.dto.ReviewStatistics;
 import com.samsamhajo.deepground.communityPlace.dto.request.AddressDto;
 import com.samsamhajo.deepground.communityPlace.dto.request.CreateReviewDto;
 import com.samsamhajo.deepground.communityPlace.dto.request.ReviewDetailDto;
@@ -107,12 +108,15 @@ public class CommunityPlaceService {
 
     }
 
-    public CommunityPlaceReview selectCommunityPlaceReviewsAndScope(Long specificAddressId) {
+    public ReviewStatistics selectCommunityPlaceReviewsAndScope(Long specificAddressId) {
 
-        CommunityPlaceReview communityPlaceReview = specificAddressRepository.findByIdCountReviewsAndScopeAverage(specificAddressId)
+        specificAddressRepository.findById(specificAddressId)
                 .orElseThrow(() -> new CommunityPlaceException(CommunityPlaceErrorCode.COMMUNITYPLACE_NOT_FOUND));
 
-        return communityPlaceReview;
+        Double avgScope = specificAddressRepository.avgScopeBySpecificAddressId(specificAddressId);
+        Long reviewCount = specificAddressRepository.countReviewBySpecificAddressId(specificAddressId);
+
+        return ReviewStatistics.of(avgScope,reviewCount);
     }
   
     //TODO: 리뷰 작성 로직 구현 후 테스트 코드 작성 후 테스트 및 SWAGGER 통해 컨트롤러 테스트 진행 예정

--- a/src/test/java/com/samsamhajo/deepground/member/service/ProfileTest.java
+++ b/src/test/java/com/samsamhajo/deepground/member/service/ProfileTest.java
@@ -90,7 +90,7 @@ public class ProfileTest {
                 .company("삼삼하조")
                 .liveIn("서울")
                 .education("컴퓨터공학과")
-                .techStack(List.of("Java", "Spring"))
+                .techStack(List.of("Java", "JavaScript"))
                 .githubUrl("https://github.com/new")
                 .linkedInUrl("https://linkedin.com/new")
                 .websiteUrl("https://new.dev")


### PR DESCRIPTION
## 📌 개요
-  `SpecificAddress`에 대한 **리뷰 통계 조회 로직(평균 평점 + 리뷰 수)**에서 발생하던 DTO 변환 오류를 해결하고,
* 엔티티 기반 로직을 **전용 DTO 구조(`ReviewStatistics`)**로 분리 및 리팩토링했습니다.

## 🛠️ 작업 내용
- `findByIdCountReviewsAndScopeAverage(...)` → 단일 통계 쿼리 2개로 분리 (`avgScopeBySpecificAddressId`, `countReviewBySpecificAddressId`)
- 반환 타입을 `CommunityPlaceReview` → `ReviewStatistics`로 변경
- 서비스 로직 내 평균 평점 및 리뷰 수 계산 후 DTO로 조립하여 응답

## 📌 차후 계획 (Optional)
- 리뷰순 및 평점순 스터디 장소 모임 오류 해결 예정
- jpql을 이용해 dto로 직접 매핑 시 성능 비교

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등
---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

close #37 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 특정 주소에 대한 리뷰의 평균 평점과 리뷰 수를 제공하는 새로운 통계 응답이 추가되었습니다.

* **버그 수정**
  * 기존에 리뷰 엔티티를 반환하던 기능이 통계 정보로 변경되어, 더 정확한 데이터 제공이 가능합니다.

* **테스트**
  * 프로필 수정 테스트의 기술 스택 데이터가 실제 사용되는 값과 일치하도록 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->